### PR TITLE
Added optional HttpClient parameter to .Initialize() methods and ApiClient

### DIFF
--- a/MoralisDotNet/Moralis.AuthApi/Client/AuthApiClient.cs
+++ b/MoralisDotNet/Moralis.AuthApi/Client/AuthApiClient.cs
@@ -1,4 +1,5 @@
-﻿using Moralis.AuthApi.Api;
+﻿using System.Net.Http;
+using Moralis.AuthApi.Api;
 using Moralis.AuthApi.Interfaces;
 using Moralis.Network;
 
@@ -41,10 +42,10 @@ namespace Moralis.AuthApi.Client
         /// ApiKey is passed via Configuration signleton.
         /// </summary>
         /// <param name="serverUrl"></param>
-        public void Initialize(string serverUrl = null)
+        public void Initialize(string serverUrl = null, HttpClient httpClient=null)
         {
             // Initialize client
-            ApiClient client = new ApiClient(serverUrl is { } ? serverUrl : defaultServerUrl);
+            ApiClient client = new ApiClient(serverUrl is { } ? serverUrl : defaultServerUrl, httpClient);
 
             AuthEndpoint = new AuthenticationApi(client);
 

--- a/MoralisDotNet/Moralis.AuthApi/Interfaces/IAuthClientApi.cs
+++ b/MoralisDotNet/Moralis.AuthApi/Interfaces/IAuthClientApi.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Net.Http;
 using System.Text;
 
 namespace Moralis.AuthApi.Interfaces
@@ -24,6 +25,6 @@ namespace Moralis.AuthApi.Interfaces
         /// ApiKey is passed via Configuration signleton.
         /// </summary>
         /// <param name="serverUrl"></param>
-        void Initialize(string serverUrl = null);
+        void Initialize(string serverUrl = null, HttpClient httpClient=null);
     }
 }

--- a/MoralisDotNet/Moralis.Network/ApiClient.cs
+++ b/MoralisDotNet/Moralis.Network/ApiClient.cs
@@ -18,14 +18,17 @@ namespace Moralis.Network
     public class ApiClient
     {
         private readonly Dictionary<String, String> _defaultHeaderMap = new Dictionary<String, String>();
+        private readonly HttpClient _httpClient;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ApiClient" /> class.
         /// </summary>
         /// <param name="basePath">The base path.</param>
-        public ApiClient(String basePath = "http://localhost:3063/api/v2")
+        /// <param name="httpClient"></param>
+        public ApiClient(string basePath = "http://localhost:3063/api/v2", HttpClient httpClient=default)
         {
             BasePath = basePath;
+            _httpClient = httpClient;
 
             _defaultHeaderMap.Add("x-moralis-platform", "C# SDK");
             _defaultHeaderMap.Add("x-moralis-platform-version", Assembly.GetExecutingAssembly().GetName().Version.ToString());
@@ -103,7 +106,7 @@ namespace Moralis.Network
                 }
             }
 
-            HttpClient client = new HttpClient();
+            HttpClient client = _httpClient ?? new HttpClient();
             client.BaseAddress = new Uri(BasePath);
 
             if (DefaultHeader != null)

--- a/MoralisDotNet/Moralis.SolanaApi/Api/AccountApi.cs
+++ b/MoralisDotNet/Moralis.SolanaApi/Api/AccountApi.cs
@@ -2,10 +2,10 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using System.Net;
+using System.Net.Http;
 using Moralis.Network;
 using Moralis.SolanaApi.Interfaces;
 using Moralis.SolanaApi.Models;
-using System.Net.Http;
 
 namespace Moralis.SolanaApi.Api
 {
@@ -28,9 +28,9 @@ namespace Moralis.SolanaApi.Api
 		/// Initializes a new instance of the <see cref="AccountApi"/> class.
 		/// </summary>
 		/// <returns></returns>
-		public AccountApi(String basePath)
+		public AccountApi(string basePath, HttpClient httpClient = null)
 		{
-			this.ApiClient = new ApiClient(basePath);
+			this.ApiClient = new ApiClient(basePath, httpClient);
 		}
 
 		/// <summary>

--- a/MoralisDotNet/Moralis.SolanaApi/Client/SolanaApiClient.cs
+++ b/MoralisDotNet/Moralis.SolanaApi/Client/SolanaApiClient.cs
@@ -1,4 +1,5 @@
-﻿using Moralis.SolanaApi.Api;
+﻿using System.Net.Http;
+using Moralis.SolanaApi.Api;
 using Moralis.SolanaApi.Interfaces;
 using Moralis.Network;
 
@@ -45,10 +46,11 @@ namespace Moralis.SolanaApi.Client
         /// ApiKey is passed via Configuration signleton.
         /// </summary>
         /// <param name="serverUrl"></param>
-        public void Initialize(string serverUrl=null)
+        /// <param name="httpClient"></param>
+        public void Initialize(string serverUrl=null, HttpClient httpClient=null)
         {
             // Initialize client
-            ApiClient client = new ApiClient(serverUrl is { } ? serverUrl : defaultServerUrl);
+            ApiClient client = new ApiClient(serverUrl is { } ? serverUrl : defaultServerUrl, httpClient);
 
             this.Account = new AccountApi(client);
             this.Nft = new NftApi(client);

--- a/MoralisDotNet/Moralis.SolanaApi/Interfaces/ISolanaApi.cs
+++ b/MoralisDotNet/Moralis.SolanaApi/Interfaces/ISolanaApi.cs
@@ -1,4 +1,5 @@
-﻿
+﻿using System.Net.Http;
+
 namespace Moralis.SolanaApi.Interfaces
 {
     public interface ISolanaApi
@@ -23,6 +24,7 @@ namespace Moralis.SolanaApi.Interfaces
         /// ApiKey is passed via Configuration signleton.
         /// </summary>
         /// <param name="serverUrl"></param>
-        void Initialize(string serverUrl = null);
+        /// <param name="httpClient"></param>
+        void Initialize(string serverUrl = null, HttpClient httpClient=null);
     }
 }

--- a/MoralisDotNet/Moralis.StreamsApi/Client/StreamsApiClient.cs
+++ b/MoralisDotNet/Moralis.StreamsApi/Client/StreamsApiClient.cs
@@ -1,4 +1,5 @@
-﻿using Moralis.Network;
+﻿using System.Net.Http;
+using Moralis.Network;
 using Moralis.StreamsApi.Api;
 using Moralis.StreamsApi.Interfaces;
 using System.Security.Cryptography;
@@ -57,10 +58,11 @@ namespace Moralis.StreamsApi.Client
         /// ApiKey is passed via Configuration signleton.
         /// </summary>
         /// <param name="serverUrl"></param>
-        public void Initialize(string serverUrl = null)
+        /// <param name="httpClient"></param>
+        public void Initialize(string serverUrl = null, HttpClient httpClient=null)
         {
             // Initialize client
-            ApiClient client = new ApiClient(serverUrl is { } ? serverUrl : defaultServerUrl);
+            ApiClient client = new ApiClient(serverUrl is { } ? serverUrl : defaultServerUrl, httpClient);
 
             BetaEndpoint = new BetaApi(client);
             HistoryEndpoint = new HistoryApi(client);

--- a/MoralisDotNet/Moralis.StreamsApi/Interfaces/IStreamsApiClient.cs
+++ b/MoralisDotNet/Moralis.StreamsApi/Interfaces/IStreamsApiClient.cs
@@ -1,4 +1,5 @@
-﻿
+﻿using System.Net.Http;
+
 namespace Moralis.StreamsApi.Interfaces
 {
     public interface IStreamsApiClient
@@ -33,7 +34,8 @@ namespace Moralis.StreamsApi.Interfaces
         /// ApiKey is passed via Configuration signleton.
         /// </summary>
         /// <param name="serverUrl"></param>
-        void Initialize(string serverUrl = null);
+        /// <param name="httpClient"></param>
+        void Initialize(string serverUrl = null, HttpClient httpClient=null);
 
         /// <summary>
         /// Verifies that a WebHook message was sent by Moralis using sha3(REQUEST_BODY + WEB3_API_KEY);

--- a/MoralisDotNet/Moralis.Web3Api/Client/Web3ApiClient.cs
+++ b/MoralisDotNet/Moralis.Web3Api/Client/Web3ApiClient.cs
@@ -1,4 +1,5 @@
-﻿using Moralis.Network;
+﻿using System.Net.Http;
+using Moralis.Network;
 using Moralis.Web3Api.Api;
 using Moralis.Web3Api.Interfaces;
 
@@ -70,10 +71,11 @@ namespace Moralis.Web3Api.Client
         /// ApiKey is passed via Configuration signleton.
         /// </summary>
         /// <param name="serverUrl"></param>
-        public void Initialize(string serverUrl=null)
+        /// <param name="httpClient"></param>
+        public void Initialize(string serverUrl = null, HttpClient httpClient = default)
         {
             // Initialize client
-            ApiClient client = new ApiClient(serverUrl is { } ? serverUrl : defaultServerUrl);
+            ApiClient client = new ApiClient(serverUrl is { } ? serverUrl : defaultServerUrl, httpClient);
 
             this.Account = new AccountApi(client);
             this.Defi = new DefiApi(client);

--- a/MoralisDotNet/Moralis.Web3Api/Interfaces/IWeb3Api.cs
+++ b/MoralisDotNet/Moralis.Web3Api/Interfaces/IWeb3Api.cs
@@ -1,4 +1,5 @@
-﻿
+﻿using System.Net.Http;
+
 namespace Moralis.Web3Api.Interfaces
 {
     public interface IWeb3Api
@@ -48,6 +49,7 @@ namespace Moralis.Web3Api.Interfaces
         /// ApiKey is passed via Configuration signleton.
         /// </summary>
         /// <param name="serverUrl"></param>
-        void Initialize(string serverUrl = null);
+        /// <param name="httpClient"></param>
+        void Initialize(string serverUrl = null, HttpClient httpClient = default);
     }
 }


### PR DESCRIPTION
It is a best-practice to use a single HttpClient instance for a whole application, not creating it at any request.
I propose to add optioanl httpClient parameter to every .Initialize() mehtod, so underlying ApiClient instance can use it.