### PR TITLE
Added DefaultHttpClient property to ApiClient class

### DIFF
--- a/MoralisDotNet/Moralis.Network/ApiClient.cs
+++ b/MoralisDotNet/Moralis.Network/ApiClient.cs
@@ -18,6 +18,7 @@ namespace Moralis.Network
     public class ApiClient
     {
         private readonly Dictionary<String, String> _defaultHeaderMap = new Dictionary<String, String>();
+        public static HttpClient DefaultHttpClient { get; set; } = null;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ApiClient" /> class.
@@ -103,7 +104,7 @@ namespace Moralis.Network
                 }
             }
 
-            HttpClient client = new HttpClient();
+            HttpClient client = DefaultHttpClient ?? new HttpClient();
             client.BaseAddress = new Uri(BasePath);
 
             if (DefaultHeader != null)


### PR DESCRIPTION
It is a best-practice to use a single HttpClient instance for a whole application, not creating it at any request.
I propose adding the DefaultHttpClient property to the ApiClient class, so that an instance of HttpClient can be provided from the application code.